### PR TITLE
行のコメントアウト機能を追加

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,14 @@
+# Extention
+
+seedtableに機能を追加したものです。
+https://github.com/seed-ui/seedtable
+
+## 追加機能
+
+ExcelのシートでIDよりも左側のセルに # と記述すると
+その行はコメントアウトとしてみなされて、YAMLへは出力されなくなります。
+この機能はEPPlusエンジンにのみ対応しています。
+
 # seedtable
 
 Rails等で扱うseed yaml <-> xlsx を相互変換するツールです。

--- a/seedtable/EPPlus.cs
+++ b/seedtable/EPPlus.cs
@@ -94,8 +94,27 @@ namespace SeedTable {
             public override string SheetName { get { return Worksheet.Name; } }
 
             public override DataDictionaryList ExcelToData(string requireVersion = "") {
-                var table = Enumerable.Range(DataStartRowIndex, Worksheet.Dimension.Rows).Select(rowIndex => GetCellValuesDictionary(rowIndex));
+                var table
+                    = Enumerable
+                        .Range(DataStartRowIndex, Worksheet.Dimension.Rows)
+                        .Where(IgnoreCommentRow)
+                        .Select(rowIndex => GetCellValuesDictionary(rowIndex));
                 return new DataDictionaryList(table, KeyColumnName);
+            }
+
+            bool IgnoreCommentRow(int rowIndex)
+            {
+                for (int i = 1; i < IdColumnIndex; i++)
+                {
+                    var value = Worksheet.Cells[rowIndex, i].Value;
+                    if (value != null && value.ToString().Trim() == "#")
+                    {
+                        // ID の列よりも左側に # がある行はコメントアウトされたとみなして無視する
+                        return false;
+                    }
+                }
+
+                return true;
             }
 
             Dictionary<string, object> GetCellValuesDictionary(int rowIndex) => Columns.ToDictionary(column => column.Name, column => Worksheet.Cells[rowIndex, column.Index].Value);


### PR DESCRIPTION
IDよりも左の列に # と入力してある行はコメントアウトとみなし、YAMLへは出力されなくなる。
最小限の変更に留めたいので、EPPlusエンジンにのみ対応。